### PR TITLE
feat: active record relation

### DIFF
--- a/stubs/ActiveQuery.phpstub
+++ b/stubs/ActiveQuery.phpstub
@@ -20,4 +20,20 @@ namespace yii\db;
  *
  * @extends Query<TModel>
  */
-class ActiveQuery extends Query {}
+class ActiveQuery extends Query
+{
+    /**
+     * @var string|null
+     */
+    public $sql;
+
+    /**
+     * @var string|array|null
+     */
+    public $on;
+
+    /**
+     * @var array|null
+     */
+    public $joinWith;
+}

--- a/stubs/ActiveQuery.phpstub
+++ b/stubs/ActiveQuery.phpstub
@@ -15,7 +15,7 @@ namespace yii\db;
  *
  * @property bool $asArray
  *
- * @method TModel one()
+ * @method TModel|null one()
  * @method array<mixed, TModel> all()
  *
  * @extends Query<TModel>

--- a/stubs/ActiveQueryInterface.phpstub
+++ b/stubs/ActiveQueryInterface.phpstub
@@ -11,9 +11,11 @@ declare(strict_types=1);
 namespace yii\db;
 
 /**
- * @template TModel
- * @method iterable<mixed, TModel> each(int $batchSize = 100, ?Connection $db = null)
+ * @psalm-template TModel
+ *
  * @method TModel|null one()
  * @method array<mixed, TModel> all()
+ *
+ * @extends QueryInterface<TModel>
  */
-class Query {}
+class ActiveQueryInterface extends QueryInterface {}

--- a/stubs/ActiveRecord.phpstub
+++ b/stubs/ActiveRecord.phpstub
@@ -13,4 +13,4 @@ namespace yii\db;
 /**
  * @method ActiveQuery<static> find();
  */
-class ActiveRecord {}
+class ActiveRecord extends BaseActiveRecord {}

--- a/stubs/ActiveRecord.phpstub
+++ b/stubs/ActiveRecord.phpstub
@@ -13,4 +13,21 @@ namespace yii\db;
 /**
  * @method ActiveQuery<static> find();
  */
-class ActiveRecord extends BaseActiveRecord {}
+class ActiveRecord extends BaseActiveRecord
+{
+    /**
+     * @param array $attributes
+     * @param string|array $condition
+     * @param array $params
+     *
+     * @return int
+     */
+    public static function updateAll($attributes, $condition = '', $params = []) {}
+
+    /**
+     * @param ActiveRecordInterface $record
+     *
+     * @return bool
+     */
+    public function equals($record) {}
+}

--- a/stubs/BaseActiveRecord.phpstub
+++ b/stubs/BaseActiveRecord.phpstub
@@ -10,10 +10,15 @@ declare(strict_types=1);
 
 namespace yii\db;
 
-/**
- * @template TModel
- * @method iterable<mixed, TModel> each(int $batchSize = 100, ?Connection $db = null)
- * @method TModel|null one()
- * @method array<mixed, TModel> all()
- */
-class Query {}
+class BaseActiveRecord
+{
+    /**
+     * @template T
+     *
+     * @param class-string<T> $class
+     * @param array $link
+     *
+     * @return ActiveQuery<T>
+     */
+    public function hasOne($class, $link): ActiveQueryInterface {}
+}

--- a/tests/Models/Category.php
+++ b/tests/Models/Category.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Copyright 2021 Practically.io All rights reserved
+ *
+ * Use of this source is governed by a BSD-style
+ * licence that can be found in the LICENCE file or at
+ * https://www.practically.io/copyright/
+ */
+declare(strict_types=1);
+
+namespace Practically\PsalmPluginYii2\Tests\Models;
+
+use yii\db\ActiveRecord;
+
+/**
+ * A test class that will mock a blog post category
+ */
+class Category extends ActiveRecord
+{
+
+    /**
+     * Override the function to return a custom query
+     */
+    public static function find(): CategoryQuery
+    {
+        return new CategoryQuery(get_called_class());
+    }
+
+    /**
+     * A test method to get the category name
+     */
+    public function getDisplyName(): string
+    {
+        return 'The category';
+    }
+
+}

--- a/tests/Models/Category.php
+++ b/tests/Models/Category.php
@@ -29,7 +29,7 @@ class Category extends ActiveRecord
     /**
      * A test method to get the category name
      */
-    public function getDisplyName(): string
+    public function getDisplayName(): string
     {
         return 'The category';
     }

--- a/tests/Models/CategoryQuery.php
+++ b/tests/Models/CategoryQuery.php
@@ -8,12 +8,19 @@
  */
 declare(strict_types=1);
 
-namespace yii\db;
+namespace Practically\PsalmPluginYii2\Tests\Models;
+
+use yii\db\ActiveQuery;
 
 /**
- * @template TModel
- * @method iterable<mixed, TModel> each(int $batchSize = 100, ?Connection $db = null)
- * @method TModel|null one()
- * @method array<mixed, TModel> all()
+ * A test class that will mock a blog post category
  */
-class Query {}
+class CategoryQuery extends ActiveQuery
+{
+
+    public function active(): self
+    {
+        return $this;
+    }
+
+}

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Copyright 2021 Practically.io All rights reserved
+ *
+ * Use of this source is governed by a BSD-style
+ * licence that can be found in the LICENCE file or at
+ * https://www.practically.io/copyright/
+ */
+declare(strict_types=1);
+
+namespace Practically\PsalmPluginYii2\Tests\Models;
+
+use yii\db\ActiveQuery;
+use yii\db\ActiveRecord;
+
+/**
+ * A test class that will mock a blog post
+ */
+class Post extends ActiveRecord
+{
+
+    /**
+     * Gets the user that created this post
+     *
+     * @return ActiveQuery<User>
+     */
+    public function getCreator(): ActiveQuery
+    {
+        return $this->hasOne(User::class, ['user_id' => 'user_id']);
+    }
+
+    /**
+     * Gets the user that created this post
+     *
+     * @return ActiveQuery<User>
+     */
+    public function getContributors(): AvtiveQuery
+    {
+        return $this->hasMany(User::class, ['user_id' => 'user_id']);
+    }
+
+}

--- a/tests/acceptance/ActiveRecordHasMany.feature
+++ b/tests/acceptance/ActiveRecordHasMany.feature
@@ -1,0 +1,51 @@
+#  Copyright 2021 Practically.io All rights reserved
+#
+#  Use of this source is governed by a BSD-style
+#  licence that can be found in the LICENCE file or at
+#  https://www.practically.io/copyright/
+
+Feature: ActiveRecord->hasMany();
+  In order to test my plugin
+  As a plugin developer
+  I need to have tests
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Practically\PsalmPluginYii2\Plugin" />
+        </plugins>
+      </psalm>
+      """
+  And I have the following code preamble
+      """
+      <?php
+      declare(strict_types=1);
+
+      namespace Practically\PsalmPluginYii2\Tests\Sandbox;
+
+      use Practically\PsalmPluginYii2\Tests\Models\Post;
+      use Practically\PsalmPluginYii2\Tests\Models\User;
+      """
+
+  Scenario: You can find one and it returns the model instance
+    Given I have the following code
+      """
+      $post = Post::find()->one();
+	  if ($post === null) {
+	  	 throw new \Exception('Not found');
+	  }
+	  
+	  $users = $post->getContributors()->all();
+	  foreach ($users as $user) {
+	      $user->getName();
+	  }
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/ActiveRecordHasOne.feature
+++ b/tests/acceptance/ActiveRecordHasOne.feature
@@ -1,0 +1,53 @@
+#  Copyright 2021 Practically.io All rights reserved
+#
+#  Use of this source is governed by a BSD-style
+#  licence that can be found in the LICENCE file or at
+#  https://www.practically.io/copyright/
+
+Feature: ActiveRecord->hasOne();
+  In order to test my plugin
+  As a plugin developer
+  I need to have tests
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+          <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Practically\PsalmPluginYii2\Plugin" />
+        </plugins>
+      </psalm>
+      """
+  And I have the following code preamble
+      """
+      <?php
+      declare(strict_types=1);
+
+      namespace Practically\PsalmPluginYii2\Tests\Sandbox;
+
+      use Practically\PsalmPluginYii2\Tests\Models\Post;
+      use Practically\PsalmPluginYii2\Tests\Models\User;
+      """
+
+  Scenario: You can find one and it returns the model instance
+    Given I have the following code
+      """
+      $post = Post::find()->one();
+	  if ($post === null) {
+	  	 throw new \Exception('Not found');
+	  }
+	  
+	  $user = $post->getCreator()->one();
+	  if ($user === null) {
+	  	 throw new \Exception('Not found');
+	  }
+
+	  $user->getName();
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/ActiveRecordOne.feature
+++ b/tests/acceptance/ActiveRecordOne.feature
@@ -37,6 +37,10 @@ Feature: ActiveRecord->one();
     Given I have the following code
       """
       $user = User::find()->one();
+	  if ($user === null) {
+	  	 throw new \Exception('Not found');
+	  }
+
       $user->getName();
       """
     When I run Psalm
@@ -45,18 +49,27 @@ Feature: ActiveRecord->one();
     Given I have the following code
       """
       $user = User::find()->one();
+	  if ($user === null) {
+	  	 throw new \Exception('Not found');
+	  }
+
       $user->getNotMyName();
       """
     When I run Psalm
     Then I see these errors
-      | Type                 | Message                                                                                |
+      | Type                 | Message                                                                                 |
       | UndefinedMagicMethod | Magic method Practically\PsalmPluginYii2\Tests\Models\User::getnotmyname does not exist |
     And I see no other errors
 
   Scenario: You can return an array when calling `asArray()`
     Given I have the following code
       """
-      $user = (array)User::find()->asArray()->one();
+	  /** @var array<string, mixed>|null */
+      $user = User::find()->asArray()->one();
+	  if ($user === null) {
+	  	 throw new \Exception('Not found');
+	  }
+
       array_pop($user);
       """
     When I run Psalm

--- a/tests/acceptance/Model.feature
+++ b/tests/acceptance/Model.feature
@@ -1,0 +1,52 @@
+#  Copyright 2021 Practically.io All rights reserved
+#
+#  Use of this source is governed by a BSD-style
+#  licence that can be found in the LICENCE file or at
+#  https://www.practically.io/copyright/
+
+Feature: Model::class;
+  In order to test my plugin
+  As a plugin developer
+  I need to have tests
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="false">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Practically\PsalmPluginYii2\Plugin" />
+        </plugins>
+      </psalm>
+      """
+  And I have the following code preamble
+      """
+      <?php
+      declare(strict_types=1);
+
+      namespace Practically\PsalmPluginYii2\Tests\Sandbox;
+	  
+      use Practically\PsalmPluginYii2\Tests\Models\User;
+	  use yii\db\ActiveQuery;
+	  use yii\db\ActiveRecord;
+      """
+  Scenario: You can create a instance of a model and its typed
+    Given I have the following code
+      """
+		/**
+		* A test class that will mock a blog post
+		*/
+        class Post extends ActiveRecord
+        {
+            /** * @return ActiveQuery<User> */
+            public function getCreator(): ActiveQuery
+            {
+                return $this->hasOne(User::class, ['user_id' => 'user_id']);
+            }
+    	}
+      """
+    When I run Psalm
+    Then I see no errors

--- a/tests/acceptance/Query.feature
+++ b/tests/acceptance/Query.feature
@@ -1,0 +1,46 @@
+#  Copyright 2021 Practically.io All rights reserved
+#
+#  Use of this source is governed by a BSD-style
+#  licence that can be found in the LICENCE file or at
+#  https://www.practically.io/copyright/
+
+Feature: Query::class;
+  In order to test my plugin
+  As a plugin developer
+  I need to have tests
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="false">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Practically\PsalmPluginYii2\Plugin" />
+        </plugins>
+      </psalm>
+      """
+  And I have the following code preamble
+      """
+      <?php
+      declare(strict_types=1);
+
+      namespace Practically\PsalmPluginYii2\Tests\Sandbox;
+	  
+	  use yii\db\ActiveQuery;
+      """
+  Scenario: You can create a instance of a model and its typed
+    Given I have the following code
+      """
+        class MyQuery extends ActiveQuery
+        {
+			public function active(): self
+			{
+				return $this;
+			}
+    	}
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
**fix: active query can return null**

When returning calling `ActiveQuery::one()` this could return null if the record
is not found. The developer must test that the return of the operation is not
null before trying to use the returned model

---

**feat: add support to active record relations**

You can now type `ActiveRecord->hasMany()` and `ActiveRecord->hasOne()` with
active record template params.

When you have the code

```php
/** @return ActiveQuery<Relation> */
public function getRelation(): ActiveQuery
{
    return $this->hasOne(Relation::class, ['id' => 'id']);
}
```

After resolving the query with `one()` or `all()` psalm will now know you have
an instance of the `Relation` class or `array<Relation>` if you call
`all()`. This prevents you from having to use `assert` or add dock blocks to
tell psalm this is a instance of a class not an `ActiveRecordInterface`

---

**feat: add model and query support**

When adding models and queries the default inheritance threw errors. This now
fixes them so you don't need to add doc blocs for every model or query you
create.