### PR TITLE
feat: add type resolution for properties via getters and setters

### DIFF
--- a/src/Handlers/BaseObjectPropertyAccessor.php
+++ b/src/Handlers/BaseObjectPropertyAccessor.php
@@ -79,8 +79,8 @@ class BaseObjectPropertyAccessor implements PropertyExistenceProviderInterface, 
         }
 
         $property_name = $event->getPropertyName();
-        if (self::doseGetterExist($codebase, $fq_classlike_name, $property_name)
-         || self::doseSetterExist($codebase, $fq_classlike_name, $property_name)
+        if (self::doesGetterExist($codebase, $fq_classlike_name, $property_name)
+         || self::doesSetterExist($codebase, $fq_classlike_name, $property_name)
         ) {
             return true;
         }
@@ -106,8 +106,8 @@ class BaseObjectPropertyAccessor implements PropertyExistenceProviderInterface, 
         }
 
         $property_name = $event->getPropertyName();
-        $setter_exists = self::doseSetterExist($codebase, $fq_classlike_name, $property_name);
-        $getter_exists = self::doseGetterExist($codebase, $fq_classlike_name, $property_name);
+        $setter_exists = self::doesSetterExist($codebase, $fq_classlike_name, $property_name);
+        $getter_exists = self::doesGetterExist($codebase, $fq_classlike_name, $property_name);
         if ($setter_exists || $getter_exists) {
             return true;
         }
@@ -133,7 +133,7 @@ class BaseObjectPropertyAccessor implements PropertyExistenceProviderInterface, 
         }
 
         $property_name = $event->getPropertyName();
-        if (self::doseGetterExist($codebase, $fq_classlike_name, $property_name)) {
+        if (self::doesGetterExist($codebase, $fq_classlike_name, $property_name)) {
             $getter = sprintf('%s::get%s', $fq_classlike_name, ucfirst($property_name));
             $type = $codebase->getMethodReturnType($getter, $fq_classlike_name);
             if ($type === null) {
@@ -164,7 +164,7 @@ class BaseObjectPropertyAccessor implements PropertyExistenceProviderInterface, 
     /**
      * Tests to see if a getter function exists on a class.
      */
-    private static function doseGetterExist(Codebase $codebase, string $fq_classlike_name, string $property_name): bool
+    private static function doesGetterExist(Codebase $codebase, string $fq_classlike_name, string $property_name): bool
     {
         $getter = sprintf('%s::get%s', $fq_classlike_name, ucfirst($property_name));
         return $codebase->methodExists($getter);
@@ -173,7 +173,7 @@ class BaseObjectPropertyAccessor implements PropertyExistenceProviderInterface, 
     /**
      * Tests to see if a setter function exists on a class
      */
-    private static function doseSetterExist(Codebase $codebase, string $fq_classlike_name, string $property_name): bool
+    private static function doesSetterExist(Codebase $codebase, string $fq_classlike_name, string $property_name): bool
     {
         $setter = sprintf('%s::set%s', $fq_classlike_name, ucfirst($property_name));
         return $codebase->methodExists($setter);

--- a/src/Handlers/BaseObjectPropertyAccessor.php
+++ b/src/Handlers/BaseObjectPropertyAccessor.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Copyright 2021 Practically.io All rights reserved
+ *
+ * Use of this source is governed by a BSD-style
+ * licence that can be found in the LICENCE file or at
+ * https://www.practically.io/copyright/
+ */
+declare(strict_types=1);
+
+namespace Practically\PsalmPluginYii2\Handlers;
+
+use Psalm\Codebase;
+use Psalm\Plugin\EventHandler\Event\PropertyExistenceProviderEvent;
+use Psalm\Plugin\EventHandler\Event\PropertyTypeProviderEvent;
+use Psalm\Plugin\EventHandler\Event\PropertyVisibilityProviderEvent;
+use Psalm\Plugin\EventHandler\PropertyExistenceProviderInterface;
+use Psalm\Plugin\EventHandler\PropertyTypeProviderInterface;
+use Psalm\Plugin\EventHandler\PropertyVisibilityProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Union;
+use RuntimeException;
+use Throwable;
+use yii\base\BaseObject;
+use yii\db\ActiveQuery;
+use yii\db\ActiveQueryInterface;
+
+/**
+ * Evaluates properties from the BaseObject getters and setters.
+ */
+class BaseObjectPropertyAccessor implements PropertyExistenceProviderInterface, PropertyVisibilityProviderInterface, PropertyTypeProviderInterface
+{
+
+    /**
+     * @var Codebase|null
+     */
+    public static $codebase = null;
+
+    /**
+     * @return array<string>
+     */
+    public static function getClassLikeNames(): array
+    {
+        $codebase = self::$codebase;
+        if ($codebase === null) {
+            throw new RuntimeException('BaseObjectPropertyAccessor::$codebase must be populated before adding the plugin.');
+        }
+
+        /** @psalm-suppress InternalMethod */
+        $classlikes = $codebase->classlikes->getMatchingClassLikeNames('*\\');
+        return array_filter(
+            $classlikes,
+            function ($fq_classlike_name) use ($codebase): bool {
+                try {
+                    return $codebase->classExtends($fq_classlike_name, BaseObject::class);
+                } catch (Throwable $e) {
+                    return false;
+                }
+            }
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function doesPropertyExist(PropertyExistenceProviderEvent $event): ?bool
+    {
+        $source = $event->getSource();
+        if (!$source || !$event->isReadMode()) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+        $fq_classlike_name = $event->getFqClasslikeName();
+
+        if (!$codebase->classExtends($fq_classlike_name, BaseObject::class)) {
+            return null;
+        }
+
+        $property_name = $event->getPropertyName();
+        if (self::doseGetterExist($codebase, $fq_classlike_name, $property_name)
+         || self::doseSetterExist($codebase, $fq_classlike_name, $property_name)
+        ) {
+            return true;
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function isPropertyVisible(PropertyVisibilityProviderEvent $event): ?bool
+    {
+        $source = $event->getSource();
+        if (!$event->isReadMode()) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+        $fq_classlike_name = $event->getFqClasslikeName();
+
+        if (!$codebase->classExtends($fq_classlike_name, BaseObject::class)) {
+            return null;
+        }
+
+        $property_name = $event->getPropertyName();
+        $setter_exists = self::doseSetterExist($codebase, $fq_classlike_name, $property_name);
+        $getter_exists = self::doseGetterExist($codebase, $fq_classlike_name, $property_name);
+        if ($setter_exists || $getter_exists) {
+            return true;
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getPropertyType(PropertyTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+        if ($source === null || !$event->isReadMode()) {
+            return null;
+        }
+
+        $codebase = $source->getCodebase();
+        $fq_classlike_name = $event->getFqClasslikeName();
+
+        if (!$codebase->classExtends($fq_classlike_name, BaseObject::class)) {
+            return null;
+        }
+
+        $property_name = $event->getPropertyName();
+        if (self::doseGetterExist($codebase, $fq_classlike_name, $property_name)) {
+            $getter = sprintf('%s::get%s', $fq_classlike_name, ucfirst($property_name));
+            $type = $codebase->getMethodReturnType($getter, $fq_classlike_name);
+            if ($type === null) {
+                return Type::getMixed();
+            }
+
+            foreach ($type->getAtomicTypes() as $atomic_type) {
+                if ($atomic_type instanceof TGenericObject) {
+                    if ($atomic_type->value === ActiveQuery::class
+                     || $codebase->classExtendsOrImplements($atomic_type->value, ActiveQueryInterface::class)
+                    ) {
+                        $type->removeType($atomic_type->getKey());
+                        foreach ($atomic_type->type_params as $param) {
+                            foreach ($param->getAtomicTypes() as $type_to_add) {
+                                $type->addType($type_to_add);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return $type;
+        }
+
+        return null;
+    }
+
+    /**
+     * Tests to see if a getter function exists on a class.
+     */
+    private static function doseGetterExist(Codebase $codebase, string $fq_classlike_name, string $property_name): bool
+    {
+        $getter = sprintf('%s::get%s', $fq_classlike_name, ucfirst($property_name));
+        return $codebase->methodExists($getter);
+    }
+
+    /**
+     * Tests to see if a setter function exists on a class
+     */
+    private static function doseSetterExist(Codebase $codebase, string $fq_classlike_name, string $property_name): bool
+    {
+        $setter = sprintf('%s::set%s', $fq_classlike_name, ucfirst($property_name));
+        return $codebase->methodExists($setter);
+    }
+
+}

--- a/src/Handlers/DifferedPluginRegistration.php
+++ b/src/Handlers/DifferedPluginRegistration.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright 2021 Practically.io All rights reserved
+ *
+ * Use of this source is governed by a BSD-style
+ * licence that can be found in the LICENCE file or at
+ * https://www.practically.io/copyright/
+ */
+declare(strict_types=1);
+
+namespace Practically\PsalmPluginYii2\Handlers;
+
+use Practically\PsalmPluginYii2\Handlers\BaseObjectPropertyAccessor;
+use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
+use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
+
+/**
+ * Differs the property event until after the codebase has been populated. This
+ * was we can add a property event handler using the classes defined in the
+ * codebase rather than doing our own scan of all the files in the application.
+ */
+class DifferedPluginRegistration implements AfterCodebasePopulatedInterface
+{
+
+    /**
+     * @inheritDoc
+     */
+    public static function afterCodebasePopulated(AfterCodebasePopulatedEvent $event)
+    {
+        BaseObjectPropertyAccessor::$codebase = $event->getCodebase();
+        /** @psalm-suppress InternalProperty */
+        $event->getCodebase()->properties->property_visibility_provider->registerClass(BaseObjectPropertyAccessor::class);
+        /** @psalm-suppress InternalProperty */
+        $event->getCodebase()->properties->property_type_provider->registerClass(BaseObjectPropertyAccessor::class);
+        /** @psalm-suppress InternalProperty */
+        $event->getCodebase()->properties->property_existence_provider->registerClass(BaseObjectPropertyAccessor::class);
+    }
+
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace Practically\PsalmPluginYii2;
 
+use Practically\PsalmPluginYii2\Handlers\DifferedPluginRegistration;
 use SimpleXMLElement;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
@@ -42,6 +43,9 @@ class Plugin implements PluginEntryPointInterface
         // configuration values there. They will be provided to your plugin
         // entry point in $config parameter, as a SimpleXmlElement object. If
         // there's no configuration present, null will be passed instead.
+
+        require_once 'Handlers/DifferedPluginRegistration.php';
+        $psalm->registerHooksFromClass(DifferedPluginRegistration::class);
     }
 
     /**

--- a/stubs/BaseObject.phpstub
+++ b/stubs/BaseObject.phpstub
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Copyright 2021 Practically.io All rights reserved
+ *
+ * Use of this source is governed by a BSD-style
+ * licence that can be found in the LICENCE file or at
+ * https://www.practically.io/copyright/
+ */
+declare(strict_types=1);
+
+namespace yii\base;
+
+/**
+ * BaseObject stub to force the class to be loaded. If we dont add this stub
+ * then psalm will not be able to find the class storage for this class
+ */
+class BaseObject {}

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -34,9 +34,19 @@ class Post extends ActiveRecord
      *
      * @return ActiveQuery<User>
      */
-    public function getContributors(): AvtiveQuery
+    public function getContributors(): ActiveQuery
     {
         return $this->hasMany(User::class, ['user_id' => 'user_id']);
+    }
+
+    /**
+     * Gets the user that created this post
+     *
+     * @return CategoryQuery<Category>
+     */
+    public function getCategory(): CategoryQuery
+    {
+        return $this->hasMany(Category::class, ['user_id' => 'user_id']);
     }
 
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -22,7 +22,7 @@ class User extends ActiveRecord
     /**
      * Gets the users name. This is used for testing that the instance of user
      * can be inferred. When calling `$user->getName()` psalm will fail if it
-     * dose not know the `$user` is an instance of `User`
+     * does not know the `$user` is an instance of `User`
      */
     public function getName(): string
     {

--- a/tests/acceptance/PropertyAccessor.feature
+++ b/tests/acceptance/PropertyAccessor.feature
@@ -1,0 +1,65 @@
+#  Copyright 2021 Practically.io All rights reserved
+#
+#  Use of this source is governed by a BSD-style
+#  licence that can be found in the LICENCE file or at
+#  https://www.practically.io/copyright/
+
+Feature: BaseObejct::get and BaseObject::set;
+  In order to test my plugin
+  As a plugin developer
+  I need to have tests
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+		<plugins>
+          <pluginClass class="Practically\PsalmPluginYii2\Plugin" />
+        </plugins>
+      </psalm>
+      """
+  And I have the following code preamble
+      """
+      <?php
+      declare(strict_types=1);
+
+      namespace Practically\PsalmPluginYii2\Tests\Sandbox;
+
+      use Practically\PsalmPluginYii2\Tests\Models\User;
+      use Practically\PsalmPluginYii2\Tests\Models\Category;
+      use Practically\PsalmPluginYii2\Tests\Models\Post;
+      """
+  Scenario: You can get a property via the magic methord __get
+    Given I have the following code
+      """
+	  function test(User $user): string
+	  {
+	      return $user->name;
+	  }
+      """
+    When I run Psalm
+    Then I see no errors
+  Scenario: You can get a model relation via the magic methord __get
+    Given I have the following code
+      """
+	  function test(Post $post): User
+	  {
+	      return $post->creator;
+	  }
+      """
+    When I run Psalm
+    Then I see no errors
+  Scenario: You can get a model relation that has a custom query class
+    Given I have the following code
+      """
+	  function test(Post $post): Category
+	  {
+	      return $post->category;
+	  }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Psalm will now know the type of magic properties via the getters and getters on
a class that extends `BaseObject`.

```php
function getTest(): int {}
```

This snippet will new resolve the property `test` to be the type of `int`

```php
/** @return ActiveQuery<Test> */
function getTest(): ActiveQuery {}
```

Also active query classes are resolved to there template type. The above snippet
will resolve a property `test` to be the class type `Test`