### PR TITLE
feat: add multiple return type from ActiveRecord

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,6 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-
     totallyTyped="true"
 >
     <projectFiles>
@@ -11,6 +10,6 @@
     </projectFiles>
 
     <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
+        <LessSpecificReturnType errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/stubs/ActiveQuery.phpstub
+++ b/stubs/ActiveQuery.phpstub
@@ -12,13 +12,15 @@ namespace yii\db;
 
 /**
  * @psalm-template TModel
+ * @psalm-template TMultiple
  *
  * @property bool $asArray
+ * @property bool $multiple
  *
  * @method TModel|null one()
  * @method array<mixed, TModel> all()
  *
- * @extends Query<TModel>
+ * @extends Query<TModel, TMultiple>
  */
 class ActiveQuery extends Query
 {

--- a/stubs/ActiveRecord.phpstub
+++ b/stubs/ActiveRecord.phpstub
@@ -11,7 +11,7 @@ declare(strict_types=1);
 namespace yii\db;
 
 /**
- * @method ActiveQuery<static> find();
+ * @method ActiveQuery<static, false> find();
  */
 class ActiveRecord extends BaseActiveRecord
 {

--- a/stubs/Query.phpstub
+++ b/stubs/Query.phpstub
@@ -12,6 +12,7 @@ namespace yii\db;
 
 /**
  * @template TModel
+ * @template TMultiple
  * @method iterable<mixed, TModel> each(int $batchSize = 100, ?Connection $db = null)
  * @method TModel|null one()
  * @method array<mixed, TModel> all()

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -22,7 +22,7 @@ class Post extends ActiveRecord
     /**
      * Gets the user that created this post
      *
-     * @return ActiveQuery<User>
+     * @return ActiveQuery<User, false>
      */
     public function getCreator(): ActiveQuery
     {
@@ -32,7 +32,7 @@ class Post extends ActiveRecord
     /**
      * Gets the user that created this post
      *
-     * @return ActiveQuery<User>
+     * @return ActiveQuery<User, true>
      */
     public function getContributors(): ActiveQuery
     {
@@ -42,11 +42,11 @@ class Post extends ActiveRecord
     /**
      * Gets the user that created this post
      *
-     * @return CategoryQuery<Category>
+     * @return CategoryQuery<Category, false>
      */
     public function getCategory(): CategoryQuery
     {
-        return $this->hasMany(Category::class, ['user_id' => 'user_id']);
+        return $this->hasOne(Category::class, ['user_id' => 'user_id']);
     }
 
 }

--- a/tests/acceptance/Model.feature
+++ b/tests/acceptance/Model.feature
@@ -41,7 +41,7 @@ Feature: Model::class;
 		*/
         class Post extends ActiveRecord
         {
-            /** * @return ActiveQuery<User> */
+            /** * @return ActiveQuery<User, false> */
             public function getCreator(): ActiveQuery
             {
                 return $this->hasOne(User::class, ['user_id' => 'user_id']);

--- a/tests/acceptance/PropertyAccessor.feature
+++ b/tests/acceptance/PropertyAccessor.feature
@@ -63,3 +63,47 @@ Feature: BaseObejct::get and BaseObject::set;
       """
     When I run Psalm
     Then I see no errors
+  Scenario: You can get a has many relation
+    Given I have the following code
+      """
+	  /** @psalm-return array<array-key, User> */
+	  function test(Post $post): array
+	  {
+	      return $post->contributors;
+	  }
+      """
+    When I run Psalm
+    Then I see no errors
+  Scenario: You can use has many in a loop
+    Given I have the following code
+      """
+	  function test(Post $post): ?User
+	  {
+		  foreach ($post->contributors as $key => $value) {
+		      /** @psalm-trace $key */
+		      return $value;
+          }
+
+          return null;
+	  }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type       | Message		                                       |
+	  | UnusedVariable | $key is never referenced or the value is not used |
+      | Trace      | $key: array-key                                       |
+    And I see no other errors
+  Scenario: Wrong return type is picked up correctly
+    Given I have the following code
+      """
+	  function test(Post $post): User
+	  {
+	      return $post->contributors;
+	  }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type                   | Message																																																				        |
+      | InvalidReturnType      | The declared return type 'Practically\PsalmPluginYii2\Tests\Models\User' for Practically\PsalmPluginYii2\Tests\Sandbox\test is incorrect, got 'array<array-key, Practically\PsalmPluginYii2\Tests\Models\User>                 |
+      | InvalidReturnStatement | The inferred type 'array<array-key, Practically\PsalmPluginYii2\Tests\Models\User>' does not match the declared return type 'Practically\PsalmPluginYii2\Tests\Models\User' for Practically\PsalmPluginYii2\Tests\Sandbox\test |
+    And I see no other errors


### PR DESCRIPTION
You now need to add if the active record return type is multiple or not. You can
define the return type like.

```
/** @return ActiveRecord<User, true> */
```

This will define that all magic getters will return an `array<array-key, User>`
if false is passed, then the magic getter is a `hasOne` relation and will return
a single user