### PR TITLE
fix: detect return type of magic prop with no getter

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
     </projectFiles>
 
     <issueHandlers>
-        <LessSpecificReturnType errorLevel="suppress" />
+        <LessSpecificReturnType errorLevel="info" />
+		<MoreSpecificImplementedParamType errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/Handlers/BaseObjectPropertyAccessor.php
+++ b/src/Handlers/BaseObjectPropertyAccessor.php
@@ -166,6 +166,17 @@ class BaseObjectPropertyAccessor implements PropertyExistenceProviderInterface, 
             return $type;
         }
 
+        if (self::doesSetterExist($codebase, $fq_classlike_name, $property_name)) {
+            $setter = sprintf('%s::set%s', $fq_classlike_name, ucfirst($property_name));
+            $params = $codebase->getMethodParams($setter);
+            if (count($params) === 0) {
+                return Type::getMixed();
+            }
+
+            $type = $params[0]->signature_type;
+            return ($type === null) ? Type::getMixed() : $type;
+        }
+
         return null;
     }
 

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -15,6 +15,9 @@ use yii\db\ActiveRecord;
 
 /**
  * A test class that will mock a blog post
+ *
+ * @property string $content
+ * @property string $contentType
  */
 class Post extends ActiveRecord
 {
@@ -47,6 +50,22 @@ class Post extends ActiveRecord
     public function getCategory(): CategoryQuery
     {
         return $this->hasOne(Category::class, ['user_id' => 'user_id']);
+    }
+
+    /**
+     * Trims the content before setting in
+     */
+    public function setContent(string $content): void
+    {
+        $this->content = \trim($content);
+    }
+
+    /**
+     * A setter with no param
+     */
+    public function setContentType(): void
+    {
+        $this->contentType = 'TYPE';
     }
 
 }

--- a/tests/acceptance/PropertyAccessor.feature
+++ b/tests/acceptance/PropertyAccessor.feature
@@ -107,3 +107,31 @@ Feature: BaseObejct::get and BaseObject::set;
       | InvalidReturnType      | The declared return type 'Practically\PsalmPluginYii2\Tests\Models\User' for Practically\PsalmPluginYii2\Tests\Sandbox\test is incorrect, got 'array<array-key, Practically\PsalmPluginYii2\Tests\Models\User>                 |
       | InvalidReturnStatement | The inferred type 'array<array-key, Practically\PsalmPluginYii2\Tests\Models\User>' does not match the declared return type 'Practically\PsalmPluginYii2\Tests\Models\User' for Practically\PsalmPluginYii2\Tests\Sandbox\test |
     And I see no other errors
+  Scenario: You can use prop if only a setter is set
+    Given I have the following code
+      """
+	  function test(Post $post): void
+	  {
+	      $content = $post->content;
+          /** @psalm-trace $content */
+          $post->content = $content . ' Testing';
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | Type       | Message          |
+      | Trace      | $content: string |
+    And I see no other errors
+  Scenario: You can use prop if only a setter is set
+    Given I have the following code
+      """
+      function test(Post $post): void
+      {
+          $contentType = $post->contentType;
+          $post->contentType = $contentType . ' Testing';
+      }
+      """
+    When I run Psalm
+    Then I see these errors
+      | MixedAssignment | Unable to determine the type that $contentType is being assigned to |
+      | MixedOperand    | Left operand cannot be mixed                                        |


### PR DESCRIPTION
When a base object setter is defined but no getter we are now getting the return
type from the first param in the setter. If you have getter that takes a
`string` the magic property will now return a string

```php
public function getThing(string $thing): void
{
    $this->thing = \trim($thing);
}
```

This is the first step in ensuing all getters and setters have consistent types
on classes that extend `BaseObject`