### PR TITLE
ci: enable actions on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   commits:


### PR DESCRIPTION
When we are getting [contributions from forks](https://github.com/Practically/PsalmPluginYii2/pull/6) the actions are running and the
tests are not getting run. This now adds the `pull_request` event into the
actions file so it all gets run