### PR TITLE
PHP 8 1 and BaseYii

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0', '8.1']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/stubs/BaseYii.phpstub
+++ b/stubs/BaseYii.phpstub
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Copyright 2021 Practically.io All rights reserved
+ *
+ * Use of this source is governed by a BSD-style
+ * licence that can be found in the LICENCE file or at
+ * https://www.practically.io/copyright/
+ */
+declare(strict_types=1);
+
+namespace yii;
+
+class BaseYii
+{
+    /**
+     * @template T
+     * @param class-string<T>|array{class: class-string<T>}|callable(): T $type
+     * @param array<mixed> $params
+     * @return T
+     */
+    public static function createObject($type, array $params = []);
+}

--- a/tests/acceptance/BaseYii.feature
+++ b/tests/acceptance/BaseYii.feature
@@ -1,0 +1,63 @@
+#  Copyright 2021 Practically.io All rights reserved
+#
+#  Use of this source is governed by a BSD-style
+#  licence that can be found in the LICENCE file or at
+#  https://www.practically.io/copyright/
+
+Feature: BaseYii::class;
+  In order to test my plugin
+  As a plugin developer
+  I need to have tests
+
+  Background:
+    Given I have the following config
+      """
+      <?xml version="1.0"?>
+      <psalm totallyTyped="true">
+        <projectFiles>
+          <directory name="."/>
+        </projectFiles>
+        <plugins>
+          <pluginClass class="Practically\PsalmPluginYii2\Plugin" />
+        </plugins>
+      </psalm>
+      """
+  And I have the following code preamble
+      """
+      <?php
+      declare(strict_types=1);
+
+	  use yii\BaseYii;
+	  use yii\db\Command;
+      """
+  Scenario: You can create and object from a class string
+    Given I have the following code
+      """
+	  function createCommand(): Command {
+	      return BaseYii::createObject(Command::class); 
+	  }
+      """
+    When I run Psalm
+    Then I see no errors
+  Scenario: You can create and object with an array and a `class` key
+    Given I have the following code
+      """
+	  function createCommand(): Command {
+	      return BaseYii::createObject(['class' => Command::class]); 
+	  }
+      """
+    When I run Psalm
+    Then I see no errors
+  Scenario: You can create and object from a callback
+    Given I have the following code
+      """
+	  function createCommand(): Command {
+	      return BaseYii::createObject(
+		      function () {
+			      return new Command;
+			  }
+		  ); 
+	  }
+      """
+    When I run Psalm
+    Then I see no errors


### PR DESCRIPTION
Add CI to test on 8.1 to ensure we support that. This is also a continuation of #6 to add tests

The plugin will now detect the return type of `Yii::createObject` from a class
string without needing to doc block the code

```php
$command = Yii::createObject(\yii\db\Command::class);
```

Psalm will now detect that command will be in instance of `yii\db\Command`. It
will also work with as array parameter with a `class` key.

```php
$command = Yii::createObject(['class' => \yii\db\Command::class]);