### PR TITLE
fix: replace totallyTyped with errorLevel

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-    totallyTyped="true"
+    errorLevel="1"
 >
     <projectFiles>
         <directory name="src" />

--- a/tests/acceptance/ActiveRecordAll.feature
+++ b/tests/acceptance/ActiveRecordAll.feature
@@ -13,7 +13,7 @@ Feature: ActiveRecord->all();
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/ActiveRecordEach.feature
+++ b/tests/acceptance/ActiveRecordEach.feature
@@ -13,7 +13,7 @@ Feature: ActiveRecord->each();
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/ActiveRecordHasMany.feature
+++ b/tests/acceptance/ActiveRecordHasMany.feature
@@ -13,7 +13,7 @@ Feature: ActiveRecord->hasMany();
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/ActiveRecordHasOne.feature
+++ b/tests/acceptance/ActiveRecordHasOne.feature
@@ -13,7 +13,7 @@ Feature: ActiveRecord->hasOne();
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/ActiveRecordOne.feature
+++ b/tests/acceptance/ActiveRecordOne.feature
@@ -13,7 +13,7 @@ Feature: ActiveRecord->one();
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
           <ignoreFiles> <directory name="../../vendor"/> </ignoreFiles>

--- a/tests/acceptance/BaseYii.feature
+++ b/tests/acceptance/BaseYii.feature
@@ -13,7 +13,7 @@ Feature: BaseYii::class;
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
         </projectFiles>

--- a/tests/acceptance/Model.feature
+++ b/tests/acceptance/Model.feature
@@ -13,7 +13,7 @@ Feature: Model::class;
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="false">
+      <psalm errorLevel="2">
         <projectFiles>
           <directory name="."/>
         </projectFiles>

--- a/tests/acceptance/PropertyAccessor.feature
+++ b/tests/acceptance/PropertyAccessor.feature
@@ -13,7 +13,7 @@ Feature: BaseObejct::get and BaseObject::set;
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="true">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
         </projectFiles>

--- a/tests/acceptance/Query.feature
+++ b/tests/acceptance/Query.feature
@@ -13,7 +13,7 @@ Feature: Query::class;
     Given I have the following config
       """
       <?xml version="1.0"?>
-      <psalm totallyTyped="false">
+      <psalm errorLevel="1">
         <projectFiles>
           <directory name="."/>
         </projectFiles>


### PR DESCRIPTION
Psalm has deprecated this config option upstream. This removes it from all our
test configs are replaces it with an error level.

Fixes-issue: #10