### PR TITLE
ci: add dependabot to project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-type: 'all'
+    commit-message:
+      prefix: "chore:"
+    assignees:
+      - "GeorgeCadwallader"
+      - "StuTheWebGuy"
+      - "davepractically"
+      - "gwynbox"

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
             "Practically\\PsalmPluginYii2\\": "src"
         }
     },
+    "config": {
+        "allow-plugins": {
+            "yiisoft/yii2-composer": true
+        }
+    },
     "autoload-dev": {
         "psr-4": {
             "Practically\\PsalmPluginYii2\\Tests\\": [


### PR DESCRIPTION
Adds dependabot to the project so we can get dependency updates into the app.