### PR TITLE
Fix #17: Support Psalm 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "vimeo/psalm": "^4.8",
+        "vimeo/psalm": "^4.8 || ^5.12",
         "yiisoft/yii2": "^2.0"
     },
     "require-dev": {

--- a/stubs/BaseActiveRecord.phpstub
+++ b/stubs/BaseActiveRecord.phpstub
@@ -10,7 +10,9 @@ declare(strict_types=1);
 
 namespace yii\db;
 
-class BaseActiveRecord
+use yii\base\Model;
+
+class BaseActiveRecord extends Model implements ActiveRecordInterface
 {
     /**
      * @template T

--- a/stubs/BaseObject.phpstub
+++ b/stubs/BaseObject.phpstub
@@ -14,4 +14,5 @@ namespace yii\base;
  * BaseObject stub to force the class to be loaded. If we dont add this stub
  * then psalm will not be able to find the class storage for this class
  */
-class BaseObject {}
+class BaseObject implements Configurable
+{}

--- a/stubs/Query.phpstub
+++ b/stubs/Query.phpstub
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace yii\db;
 
+use yii\base\Component;
+
 /**
  * @template TModel
  * @template TMultiple
@@ -17,4 +19,5 @@ namespace yii\db;
  * @method TModel|null one()
  * @method array<mixed, TModel> all()
  */
-class Query {}
+class Query extends Component implements QueryInterface, ExpressionInterface
+{}

--- a/tests/acceptance/Query.feature
+++ b/tests/acceptance/Query.feature
@@ -28,12 +28,17 @@ Feature: Query::class;
       declare(strict_types=1);
 
       namespace Practically\PsalmPluginYii2\Tests\Sandbox;
-	  
+
 	  use yii\db\ActiveQuery;
       """
   Scenario: You can create a instance of a model and its typed
     Given I have the following code
       """
+        /**
+         * @template TModel
+         * @template TMultiple
+         * @extends ActiveQuery<TModel, TMultiple>
+         */
         class MyQuery extends ActiveQuery
         {
 			public function active(): self


### PR DESCRIPTION
I am not sure about my edit of the test for `tests/acceptance/Query.feature`, please review.
Without this edit it was failing like such:
```
There was 1 failure:

---------
1) Query::class;: You can create a instance of a model and its typed
 Test  tests/acceptance/Query.feature:You can create a instance of a model and its typed
 Step  Can see no errors 
 Fail  There were errors: 
| MissingTemplateParam | Practically\PsalmPluginYii2\Tests\Sandbox\MyQuery has missing template params when extending yii\db\ActiveQuery, expecting 2 |

Scenario Steps:

 13. $I->canSeeNoErrors()
 12. $I->runPsalm()
 11. $I->haveTheFollowingCode("  class MyQuery extends ActiveQuery\n  {\npublic function active(): self\n{\nreturn $this;\n}\n}")
 10. $I->haveTheFollowingCodePreamble("<?php\ndeclare(strict_types=1);\n\nnamespace Practically\PsalmPluginYii2\Tests\Sandbox;\n\nuse yii\db\ActiveQuery;")
 9. $I->haveTheFollowingConfig("<?xml version="1.0"?>\n<psalm errorLevel="1">\n  <projectFiles>\n    <directory name="."/>\n  </projectFiles>\n  <plugins>\n    <pluginClass class="Practically\PsalmPluginYii2\Plugin" />...")
 8. // I need to have tests


FAILURES!
Tests: 22, Assertions: 1, Failures: 1.
Script codecept build && codecept run handling the test event returned with error code 1
```

While with this edit tests are passed:
```
composer run-script test
> codecept build && codecept run
Building Actor classes for suites: acceptance
 -> AcceptanceTesterActions.php generated successfully. 43 methods added
Practically\PsalmPluginYii2\Tests\AcceptanceTester includes modules: Cli, Filesystem, \Weirdan\Codeception\Psalm\Module, \Practically\PsalmPluginYii2\Tests\Helper\Acceptance
Codeception PHP Testing Framework v4.2.2 https://helpukrainewin.org
Powered by PHPUnit 9.6.8 by Sebastian Bergmann and contributors.

Practically\PsalmPluginYii2\Tests.acceptance Tests (22) -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
✔ ActiveRecord->all();: You can find all and loop through them (1.94s)
✔ ActiveRecord->all();: You get errors when calling invalid methods after finding all and looping though (1.90s)
✔ ActiveRecord->each();: You can loop through with `each()` (1.91s)
✔ ActiveRecord->each();: You can loop through with `each()` but files on bad function call (2.11s)
✔ ActiveRecord->hasMany();: You can find one and it returns the model instance (1.92s)
✔ ActiveRecord->hasOne();: You can find one and it returns the model instance (1.94s)
✔ ActiveRecord->one();: You can find one and it returns the model instance (1.89s)
✔ ActiveRecord->one();: You get errors when calling invalid methods after finding one (1.90s)
✔ ActiveRecord->one();: You can return an array when calling `asArray()` (1.90s)
✔ BaseYii::class;: You can create and object from a class string (2.29s)
✔ BaseYii::class;: You can create and object with an array and a `class` key (2.26s)
✔ BaseYii::class;: You can create and object from a callback (2.22s)
✔ Model::class;: You can create a instance of a model and its typed (1.96s)
✔ BaseObejct::get and BaseObject::set;: You can get a property via the magic methord __get (1.92s)
✔ BaseObejct::get and BaseObject::set;: You can get a model relation via the magic methord __get (1.87s)
✔ BaseObejct::get and BaseObject::set;: You can get a model relation that has a custom query class (1.89s)
✔ BaseObejct::get and BaseObject::set;: You can get a has many relation (1.88s)
✔ BaseObejct::get and BaseObject::set;: You can use has many in a loop (1.89s)
✔ BaseObejct::get and BaseObject::set;: Wrong return type is picked up correctly (1.89s)
✔ BaseObejct::get and BaseObject::set;: You can use prop if only a setter is set (1.93s)
✔ BaseObejct::get and BaseObject::set;: You can use prop if only a setter is set (1.95s)
✔ Query::class;: You can create a instance of a model and its typed (1.95s)
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


Time: 00:43.338, Memory: 10.00 MB

OK (22 tests, 0 assertions)

```